### PR TITLE
Allow the user of integrator to specify which source control provider…

### DIFF
--- a/integrator.rb
+++ b/integrator.rb
@@ -15,11 +15,19 @@ def get_options
   retval = {}
   retval[:force_build] = false
   retval[:forced_build_name] = ''
+  retval[:provider] = ''
 
   opt_parser = OptionParser.new do |opts|
-    opts.banner = "Usage: example.rb [options]"
+    opts.banner = "Usage: integrator.rb [options]"
 
     # Optional argument; multi-line description.
+
+    opts.on("-p", "--provider [PROVIDER]", "One of 'gitlab', 'github', or 'bitbucket'.") do |provider|
+      retval[:provider] = provider
+      unless ["gitlab", "github", "bitbucket"].include? provider
+        abort("Provider(-p) must be one of 'gitlab', 'github' or 'bitbucket'")
+      end
+    end
 
     opts.on("-f", "--force [BUILD_NAME]", "Forces a build on repo with name BUILD_NAME") do |build|
       retval[:force_build] = true
@@ -30,9 +38,11 @@ def get_options
   retval
 end
 
-sc = SourceControl.new
-req, http = sc.connect()
 options = get_options
+
+sc = SourceControl.new
+req, http, provider = sc.connect(options[:provider])
+
 
 while true
   build_triggered = false
@@ -40,15 +50,19 @@ while true
   resp = http.request(req)
 
   repos = JSON.parse(resp.body)
+
   repos.each do |repo|
-    local_repo = Repos.get(repo)
+    local_repo = Repos.get(repo, provider)
 
     if options[:force_build]
+      puts "Forcing Build"
       if local_repo.name == options[:forced_build_name]
+        puts "Build found, building #{options[:forced_build_name]}"
         job = Job.new(
           local_repo: local_repo,
           updated: repo["last_updated"]
         )
+
         job.trigger()
         build_triggered = true
         options[:force_build] = false
@@ -57,7 +71,7 @@ while true
       end
     end
 
-    if local_repo.been_updated? repo["last_updated"]
+    if local_repo.been_updated? repo.last_updated()
       job = Job.new(
         local_repo: local_repo,
         updated: repo["last_updated"]

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'job'
+require 'repo'
+
+gitlab_object = {"id"=>7400891, "description"=>"Gitlab App Description", "name"=>"gitlab_app", "name_with_namespace"=>"integrator / gitlab_app", "path"=>"gitlab_app", "path_with_namespace"=>"integrator/gitlab_app", "created_at"=>"2018-07-08T02:52:23.971Z", "default_branch"=>"master", "tag_list"=>[], "ssh_url_to_repo"=>"git@gitlab.com:integrator/gitlab_app.git", "http_url_to_repo"=>"https://gitlab.com/integrator/gitlab_app.git", "web_url"=>"https://gitlab.com/integrator/gitlab_app", "readme_url"=>"https://gitlab.com/integrator/gitlab_app/blob/master/README.md", "avatar_url"=>nil, "star_count"=>0, "forks_count"=>0, "last_activity_at"=>"2018-08-03T04:07:54.695Z", "namespace"=>{"id"=>3196837, "name"=>"integrator", "path"=>"integrator", "kind"=>"user", "full_path"=>"integrator", "parent_id"=>nil}, "_links"=>{"self"=>"https://gitlab.com/api/v4/projects/7400891", "issues"=>"https://gitlab.com/api/v4/projects/7400891/issues", "merge_requests"=>"https://gitlab.com/api/v4/projects/7400891/merge_requests", "repo_branches"=>"https://gitlab.com/api/v4/projects/7400891/repository/branches", "labels"=>"https://gitlab.com/api/v4/projects/7400891/labels", "events"=>"https://gitlab.com/api/v4/projects/7400891/events", "members"=>"https://gitlab.com/api/v4/projects/7400891/members"}, "archived"=>false, "visibility"=>"private", "owner"=>{"id"=>2555218, "name"=>"integrator", "username"=>"integrator", "state"=>"active", "avatar_url"=>"https://secure.gravatar.com/avatar/00000000000000000000000000000000?s=80&d=identicon", "web_url"=>"https://gitlab.com/integrator"}, "resolve_outdated_diff_discussions"=>false, "container_registry_enabled"=>true, "issues_enabled"=>true, "merge_requests_enabled"=>true, "wiki_enabled"=>true, "jobs_enabled"=>true, "snippets_enabled"=>true, "shared_runners_enabled"=>true, "lfs_enabled"=>true, "creator_id"=>2555218, "import_status"=>"none", "open_issues_count"=>0, "public_jobs"=>true, "ci_config_path"=>nil, "shared_with_groups"=>[], "only_allow_merge_if_pipeline_succeeds"=>false, "request_access_enabled"=>false, "only_allow_merge_if_all_discussions_are_resolved"=>false, "printing_merge_request_link_enabled"=>true, "merge_method"=>"merge", "permissions"=>{"project_access"=>{"access_level"=>40, "notification_level"=>3}, "group_access"=>nil}, "mirror"=>false}
+
+RSpec.describe Repo do
+  it "gets the proper uri" do
+    local_repo = Repo.new(repo_obj)
+    expect local_repo.uri.to be("https://gitlab.com/integrator/gitlab_app.git")
+  end
+end

--- a/src/repo.rb
+++ b/src/repo.rb
@@ -9,8 +9,9 @@ class Repo
   attr_accessor :name, :last_updated, :created_on, :logo, :slug
 
   @trigger_build = false
-  def initialize(repo_obj)
+  def initialize(repo_obj, provider)
     @g            = nil
+    @provider     = provider
     @repo_obj     = repo_obj
     @created_on   = repo_obj['created_on']
     @name         = repo_obj['name']
@@ -38,6 +39,11 @@ class Repo
     "/tmp/checkout/#{@name}"
   end
 
+  def last_updated
+    return  @repo_obj["last_activity_at"] if @provider == "gitlab"
+    return @repo_obj["last_updated"]
+  end
+
   def checkout_dir
     "/tmp/checkout/#{@name}"
   end
@@ -46,7 +52,9 @@ class Repo
     if @name.end_with?("/")
       @name.chomp("/")
     end
-    "#{@owner}@bitbucket.org:#{@owner}/#{@name}.git"
+    return @repo_obj["ssh_url_to_repo"] if @provider == "gitlab"
+
+    "#{@owner}@bitbucket.org:#{@owner}/#{@name}.git" if @provider == "bitbucket"
   end
 
   def trigger_build?

--- a/src/repos.rb
+++ b/src/repos.rb
@@ -6,12 +6,12 @@ require 'repo'
 class Repos
   @repos = []
 
-  def self.get(repo_obj)
+  def self.get(repo_obj, provider)
     list.each do |item|
       next if item.slug != repo_obj["slug"]
       return item
     end
-    repo = Repo.new repo_obj
+    repo = Repo.new repo_obj, provider
     @repos.push(repo)
     repo
   end


### PR DESCRIPTION
The current version of integrator intuits which source control provider you want to use, based on the environment variables that are set.  This change updates it so you can set the provider on the command line, in case the environment variables are set for multiple source control providers.